### PR TITLE
Fix link time optimization and linking order for CentOS 7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,14 @@
 cmake_minimum_required(VERSION 3.14)
 project(apex VERSION 0.0.1)
 include(CTest)
+include(CheckIPOSupported)
+
+check_ipo_supported(RESULT LTO_SUPPORTED OUTPUT LTO_ERROR)
+if (LTO_SUPPORTED)
+  message(STATUS "Link time optimization is available on this system")
+else()
+  message(STATUS "Link time optimization not supported on this system: <${LTO_ERROR}>")
+endif()
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
 set(CMAKE_CXX_STANDARD 14)
@@ -82,13 +90,23 @@ set(APEX_SOURCE
 
 add_library(apex ${APEX_HEADERS} ${APEX_SOURCE})
 
-# Do not use LTO in debug mode, symbols get messed up & breakpoints will not work correctly
-target_compile_options(apex PUBLIC "$<$<NOT:$<PLATFORM_ID:Darwin>>:-static>" "$<$<CONFIG:RELEASE>:-flto>" -Wall -Wpedantic -fno-math-errno)
+if(CMAKE_BUILD_TYPE MATCHES "Release|RELEASE")
+  set(IS_RELEASE TRUE)
+endif()
+
+if (LTO_SUPPORTED AND IS_RELEASE)
+  message(STATUS "Link time optimization enabled")
+  set_property(TARGET apex PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+else()
+  message(STATUS "Link time optimization disabled")
+endif()
+
+target_compile_options(apex PUBLIC "$<$<NOT:$<PLATFORM_ID:Darwin>>:-static>")
 
 # -static not supported on MacOS, can't statically link to C runtime
-target_link_options(apex PUBLIC "$<$<NOT:$<PLATFORM_ID:Darwin>>:-static>" "$<$<CONFIG:RELEASE>:-flto>" -Wno-unused-function)
+target_link_options(apex PUBLIC "$<$<NOT:$<PLATFORM_ID:Darwin>>:-static>" -Wno-unused-function)
 target_include_directories(apex PUBLIC ${CGET_PREFIX}/include src src/BRENT)
-target_link_libraries(apex PUBLIC ${LIB_ZSTD} ${LIB_LZMA} ${LIB_Z} ${LIB_HTS} ${LIB_RMATH} ${Boost_LIBRARIES})
+target_link_libraries(apex PUBLIC ${LIB_HTS} ${LIB_ZSTD} ${LIB_LZMA} ${LIB_Z} ${LIB_RMATH} ${Boost_LIBRARIES})
 
 if(OpenMP_CXX_FOUND)
   target_compile_options(apex PUBLIC "${OpenMP_CXX_FLAGS}")

--- a/Dockerfile-CentOS7
+++ b/Dockerfile-CentOS7
@@ -1,0 +1,78 @@
+FROM centos:centos7 as base
+
+# Install required packages for apex to install.
+RUN yum update -y && \
+  yum install -y centos-release-scl && \
+  yum install -y \
+    devtoolset-9 \
+    zlib-devel \
+    python-devel \
+    glibc-static \
+    python3 \
+    python3-devel && \
+  yum -y clean all && \
+  rm -rf /var/cache
+
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+
+RUN echo "source /opt/rh/devtoolset-9/enable" >> /etc/bashrc
+SHELL ["/bin/bash", "--login", "-c"]
+
+RUN curl -OJL https://github.com/Kitware/CMake/releases/download/v3.25.1/cmake-3.25.1-linux-x86_64.sh && \
+  bash cmake-3.25.1-linux-x86_64.sh --skip-license --prefix=/usr/local
+
+# Install python dependencies
+RUN pip3 install --upgrade pip && \
+    pip3 install cget
+
+# Create a group and user to execute as, then drop root
+RUN adduser --user-group --create-home --shell /bin/bash apex
+
+WORKDIR /home/apex
+USER apex
+
+# Install cpp dependencies
+COPY --chown=apex:apex requirements.txt /home/apex/requirements.txt
+COPY --chown=apex:apex *.cmake /home/apex/
+ARG CMAKE_BUILD_PARALLEL_LEVEL
+ARG MAKEFLAGS
+RUN cget install -f requirements.txt
+
+# Next stage: compile
+FROM base as compile
+
+# Copy source
+COPY --chown=apex:apex CMakeLists.txt /home/apex/CMakeLists.txt
+COPY --chown=apex:apex ./src /home/apex/src
+COPY --chown=apex:apex ./tests /home/apex/tests
+
+# Run compile
+ENV CGET_PREFIX="/home/apex/cget"
+ENV INSTALL_PREFIX="/home/apex/cget"
+RUN \
+  mkdir build \
+  && cd build \
+  && cmake .. \
+    -DCMAKE_TOOLCHAIN_FILE=${CGET_PREFIX}/cget/cget.cmake \
+    -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
+    -DCMAKE_BUILD_TYPE=Release
+RUN cd build && cmake --build . --target apex
+RUN cd build && cmake --build . --target apex-bin
+RUN cd build && cmake --build . --target tests
+
+# Run test cases
+FROM compile as test
+RUN cd tests && ../build/tests/tests
+
+# Frequently changing metadata here to avoid cache misses
+ARG BUILD_DATE
+ARG GIT_SHA
+ARG APEX_VERSION
+
+LABEL org.label-schema.version=$apex_VERSION \
+      org.label-schema.vcs-ref=$GIT_SHA \
+      org.label-schema.build-date=$BUILD_DATE
+
+# Set the default stage to be the base files + compiled binaries + test cases.
+FROM test


### PR DESCRIPTION
Hopefully this should fix all remaining issues for building on CentOS 7. 🤞 There seemed to be an issue with link time optimization (LTO) specifically on that OS, and CMake was not setup to use it correctly. The order in which libraries were linked also seemed to not work for CentOS 7, but I'm not quite sure why it worked on Ubuntu - maybe a newer version of gcc/g++ and/or CMake are automatically able to correct the problem. 

The `Dockerfile-CentOS7` creates a clean CentOS 7 docker image with all necessary system dependencies installed, and then proceeds to compile and test apex. So I know that at least in theory, it's possible for apex to compile now on that OS. 

If it still won't compile on your system there, it would be worth looking through that file to see how your system might differ as far as what dependencies are installed. You could also potentially just copy the apex executable out from the created docker image and use it on your system. There is an example of doing this in the [bin/make_linux.sh](https://github.com/lin-lab/apex/blob/master/bin/make_linux.sh) script that I used for creating a distributable tarball with a static executable of apex (although it uses the Ubuntu image by default.) 

Let me know if you run into any trouble and hopefully we can find the issue. 